### PR TITLE
Refactor toggle/cb and fix won bool

### DIFF
--- a/fallouthacking/client/main.lua
+++ b/fallouthacking/client/main.lua
@@ -47,9 +47,6 @@ RegisterNUICallback("Win", function()
     end
 
     SetNuiFocus(false, false)
-    SendNUIMessage({
-        action = "close"
-    })
 end)
 
 exports("start", startMinigame)

--- a/fallouthacking/client/main.lua
+++ b/fallouthacking/client/main.lua
@@ -1,15 +1,39 @@
-AddEventHandler('fallouthacking:client:StartMinigame', function(wordLength, retryCount, callback)
-    minigameCallback = callback
+local successPromise = nil
+
+--- Starts the minigame with provided field
+---@param wordLength integer The difficulty (the character length of the words)
+---@param retryCount integer How many attempts you have
+local function startMinigame(wordLength, retryCount)
+    if successPromise then return error("minigame already active") end
+
+    successPromise = promise.new()
     SendNUIMessage({
         action = "open",
         length = wordLength,
         retries = retryCount,
     })
     SetNuiFocus(true, true)
-end)
+
+    return Citizen.Await(successPromise)
+end
+
+local function cancelMinigame()
+    if successPromise then
+        successPromise:resolve(false)
+        successPromise = nil
+        SetNuiFocus(false, false)
+        SendNUIMessage({
+            action = "close"
+        })
+    end
+end
 
 RegisterNUICallback("Close", function()
-    minigameCallback(false)
+    if successPromise then
+        successPromise:resolve(false)
+        successPromise = nil
+    end
+
     SetNuiFocus(false, false)
     SendNUIMessage({
         action = "close"
@@ -17,9 +41,16 @@ RegisterNUICallback("Close", function()
 end)
 
 RegisterNUICallback("Win", function()
-    minigameCallback(true)
+    if successPromise then
+        successPromise:resolve(true)
+        successPromise = nil
+    end
+
     SetNuiFocus(false, false)
     SendNUIMessage({
         action = "close"
     })
 end)
+
+exports("start", startMinigame)
+exports("cancel", cancelMinigame)

--- a/fallouthacking/html/robco-industries/js/terminal.js
+++ b/fallouthacking/html/robco-industries/js/terminal.js
@@ -527,7 +527,6 @@ Success = function()
 }
 
 WinCondition = function() {
-	TogglePower();
 	$.post(`https://${GetParentResourceName()}/Win`);
 }
 

--- a/fallouthacking/html/robco-industries/js/terminal.js
+++ b/fallouthacking/html/robco-industries/js/terminal.js
@@ -527,6 +527,15 @@ Success = function()
 }
 
 WinCondition = function() {
+  Power = "off";
+	$("#terminal-background-off").css("visibility", "visible");
+	$("#terminal").css("background-image", "url('robco-industries/img/bg-off.png')");
+	$("#terminal").html("");
+	if (Sound) {
+		$("#poweroff")[0].play();
+		$("#minigame").hide();
+  }
+  
 	$.post(`https://${GetParentResourceName()}/Win`);
 }
 


### PR DESCRIPTION
### Refactoring
* Toggling is now done via an export instead of an event.
* The success boolean is now handled via a promise instead of a callback.
* Added a cancel export to manually cancel the game if needed.

### Fixes
* Resolved the success boolean being false when you win the minigame.